### PR TITLE
GopherJS typo fix and gen.go robustness improvement

### DIFF
--- a/docs/cheatsheet.html
+++ b/docs/cheatsheet.html
@@ -338,7 +338,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fcheatsheet.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fcheatsheet.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/cheatsheet.html
+++ b/docs/cheatsheet.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/2048.html
+++ b/docs/examples/2048.html
@@ -83,7 +83,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2f2048.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2f2048.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/2048.html
+++ b/docs/examples/2048.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/airship.html
+++ b/docs/examples/airship.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fairship.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fairship.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/airship.html
+++ b/docs/examples/airship.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/animation.html
+++ b/docs/examples/animation.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fanimation.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fanimation.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/animation.html
+++ b/docs/examples/animation.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/audio.html
+++ b/docs/examples/audio.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2faudio.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2faudio.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/audio.html
+++ b/docs/examples/audio.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/blocks.html
+++ b/docs/examples/blocks.html
@@ -83,7 +83,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fblocks.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fblocks.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/blocks.html
+++ b/docs/examples/blocks.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/blur.html
+++ b/docs/examples/blur.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fblur.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fblur.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/blur.html
+++ b/docs/examples/blur.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/drag.html
+++ b/docs/examples/drag.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fdrag.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fdrag.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/drag.html
+++ b/docs/examples/drag.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/filter.html
+++ b/docs/examples/filter.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ffilter.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ffilter.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/filter.html
+++ b/docs/examples/filter.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/flappy.html
+++ b/docs/examples/flappy.html
@@ -83,7 +83,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fflappy.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fflappy.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/flappy.html
+++ b/docs/examples/flappy.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/flood.html
+++ b/docs/examples/flood.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/flood.html
+++ b/docs/examples/flood.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fflood.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fflood.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/font.html
+++ b/docs/examples/font.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ffont.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ffont.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/font.html
+++ b/docs/examples/font.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/gamepad.html
+++ b/docs/examples/gamepad.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fgamepad.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fgamepad.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/gamepad.html
+++ b/docs/examples/gamepad.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/highdpi.html
+++ b/docs/examples/highdpi.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fhighdpi.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fhighdpi.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/highdpi.html
+++ b/docs/examples/highdpi.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/hsv.html
+++ b/docs/examples/hsv.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fhsv.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fhsv.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/hsv.html
+++ b/docs/examples/hsv.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -252,7 +252,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2f%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2f%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/infinitescroll.html
+++ b/docs/examples/infinitescroll.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2finfinitescroll.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2finfinitescroll.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/infinitescroll.html
+++ b/docs/examples/infinitescroll.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/keyboard.html
+++ b/docs/examples/keyboard.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fkeyboard.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fkeyboard.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/keyboard.html
+++ b/docs/examples/keyboard.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/life.html
+++ b/docs/examples/life.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2flife.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2flife.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/life.html
+++ b/docs/examples/life.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/mandelbrot.html
+++ b/docs/examples/mandelbrot.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fmandelbrot.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fmandelbrot.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/mandelbrot.html
+++ b/docs/examples/mandelbrot.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/masking.html
+++ b/docs/examples/masking.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fmasking.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fmasking.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/masking.html
+++ b/docs/examples/masking.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/mosaic.html
+++ b/docs/examples/mosaic.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/mosaic.html
+++ b/docs/examples/mosaic.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fmosaic.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fmosaic.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/noise.html
+++ b/docs/examples/noise.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fnoise.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fnoise.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/noise.html
+++ b/docs/examples/noise.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/paint.html
+++ b/docs/examples/paint.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fpaint.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fpaint.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/paint.html
+++ b/docs/examples/paint.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/particles.html
+++ b/docs/examples/particles.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fparticles.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fparticles.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/particles.html
+++ b/docs/examples/particles.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/perspective.html
+++ b/docs/examples/perspective.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fperspective.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fperspective.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/perspective.html
+++ b/docs/examples/perspective.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/piano.html
+++ b/docs/examples/piano.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fpiano.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fpiano.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/piano.html
+++ b/docs/examples/piano.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/polygons.html
+++ b/docs/examples/polygons.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fpolygons.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fpolygons.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/polygons.html
+++ b/docs/examples/polygons.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/raycasting.html
+++ b/docs/examples/raycasting.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fraycasting.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fraycasting.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/raycasting.html
+++ b/docs/examples/raycasting.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/sinewave.html
+++ b/docs/examples/sinewave.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fsinewave.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fsinewave.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/sinewave.html
+++ b/docs/examples/sinewave.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/sprites.html
+++ b/docs/examples/sprites.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fsprites.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fsprites.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/sprites.html
+++ b/docs/examples/sprites.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/tiles.html
+++ b/docs/examples/tiles.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ftiles.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ftiles.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/tiles.html
+++ b/docs/examples/tiles.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/typewriter.html
+++ b/docs/examples/typewriter.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ftypewriter.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2ftypewriter.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/typewriter.html
+++ b/docs/examples/typewriter.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/examples/wheel.html
+++ b/docs/examples/wheel.html
@@ -86,7 +86,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fwheel.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fexamples%2fwheel.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/examples/wheel.html
+++ b/docs/examples/wheel.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -95,7 +95,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2ffaq.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2ffaq.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/fill.html
+++ b/docs/fill.html
@@ -96,7 +96,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2ffill.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2ffill.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/fill.html
+++ b/docs/fill.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/geometrymatrix.html
+++ b/docs/geometrymatrix.html
@@ -184,7 +184,11 @@ g
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fgeometrymatrix.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fgeometrymatrix.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/geometrymatrix.html
+++ b/docs/geometrymatrix.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/gopherjs.html
+++ b/docs/gopherjs.html
@@ -101,7 +101,11 @@ go1.12.13 download</code></pre>
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fgopherjs.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fgopherjs.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/gopherjs.html
+++ b/docs/gopherjs.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/helloworld.html
+++ b/docs/helloworld.html
@@ -133,7 +133,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fhelloworld.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fhelloworld.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/helloworld.html
+++ b/docs/helloworld.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -77,7 +77,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fimplementation.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fimplementation.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,7 +152,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/install.html
+++ b/docs/install.html
@@ -261,7 +261,11 @@ go run -tags=example ./examples/rotate</code></pre>
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2finstall.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2finstall.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/install.html
+++ b/docs/install.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -277,7 +277,11 @@ func UpdateTouchesOnIOS(phase int, ptr int64, x, y int) {
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fmobile.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fmobile.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/mobile.html
+++ b/docs/mobile.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/packages.html
+++ b/docs/packages.html
@@ -102,7 +102,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fpackages.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fpackages.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/packages.html
+++ b/docs/packages.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/performancetips.html
+++ b/docs/performancetips.html
@@ -131,7 +131,11 @@ B.DrawImage(A, op) // cyclic drawing! Avoid this if possible.</code></pre>
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fperformancetips.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fperformancetips.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/performancetips.html
+++ b/docs/performancetips.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/renderimage.html
+++ b/docs/renderimage.html
@@ -122,7 +122,11 @@
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2frenderimage.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2frenderimage.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/renderimage.html
+++ b/docs/renderimage.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/docs/webassembly.html
+++ b/docs/webassembly.html
@@ -108,7 +108,11 @@ WebAssembly.instantiateStreaming(fetch("yourgame.wasm"), go.importObject).then(r
 
       </article>
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fwebassembly.html%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body=https%3a%2f%2febiten.org%2fwebassembly.html%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
     </main>
   </body>

--- a/docs/webassembly.html
+++ b/docs/webassembly.html
@@ -58,7 +58,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>

--- a/gen.go
+++ b/gen.go
@@ -153,7 +153,9 @@ func run() error {
 		case "index.html":
 			canonical = url
 		default:
-			canonical = url + "/" + rel
+			// When generated on a Windows machine, rel will have \ characters.
+			// Use ToSlash to ensure that all path separators are /.
+			canonical = url + "/" + filepath.ToSlash(rel)
 			canonical = strings.TrimSuffix(canonical, "index.html")
 		}
 

--- a/tmpl.html
+++ b/tmpl.html
@@ -77,7 +77,11 @@
       </article>
       {{if .Feedback -}}
       <footer>
-        <p><a href="https://github.com/ebiten/ebiten.org/issues/new?body={{.Canonical}}%0a%0a">Please feedback about this page</a>. Thank you!</p>
+        <p>
+            Feedback about this page?
+            <a href="https://github.com/ebiten/ebiten.org/issues/new?body={{.Canonical}}%0a%0a">Please reach out on GitHub</a>.
+            Thank you!
+        </p>
       </footer>
       {{- end}}
     </main>

--- a/tmpl.html
+++ b/tmpl.html
@@ -59,7 +59,7 @@
       <ul>
         <li><a href="/mobile.html">Mobile</a></li>
         <li><a href="/webassembly.html">WebAssembly</a></li>
-        <li><a href="/gopherjs.html">GopehrJS</a></li>
+        <li><a href="/gopherjs.html">GopherJS</a></li>
       </ul>
       <h2>Documents</h2>
       <ul>


### PR DESCRIPTION
# Overview

This PR fixes a typo in the navigation ("GopehrJS") and updates the wording in the feedback footer.

It also adds a robustness fix to ensure that each page's canonical URL is created correctly when generating on Windows: the `rel` variable that is created while walking the file tree has `\` characters on Windows, and this corrupts the value of `canonical` when generating the HTML files.

# Changes

**tmpl.html**:

- Fixed typo "GopehrJS"
- Updated wording in feedback section

**gen.go**:

- Use `filepath.ToSlash` when setting canonical URL to ensure that `\` characters used to separate filepaths on Windows do not corrupt URL's, which require `/` as separators.

# Testing

Open the root directory and run `go generate .` to build the HTML files.

Verify that the files generate without issue and use `git diff` to verify that nothing changes (updated HTML files have been committed to `docs/` directory).

If possible, generate on Windows and verify that the canonical URLs do not change.