### PR TITLE
Updates to English on homepage & examples page

### DIFF
--- a/contents/examples/index.html
+++ b/contents/examples/index.html
@@ -4,17 +4,17 @@
   <div class="grid-item-1">
     <h3>Animation</h3>
     <p class="img thumbnail"><a href="animation.html"><img src="/images/examples/animation.png" width="320" height="240" alt="Animation"></a></p>
-    <p>Animation by changing the source region of an image by <code>SubImage</code>.</p>
+    <p>Animation by changing the source region of an image using <code>SubImage</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Blur</h3>
     <p class="img thumbnail"><a href="blur.html"><img src="/images/examples/blur.png" width="320" height="240" alt="Blur"></a></p>
-    <p>Bluring an image by rending the same image multiple times.</p>
-nn  </div>
+    <p>Blurring an image by rendering the same image multiple times.</p>
+  </div>
   <div class="grid-item-1">
     <h3>Filter</h3>
     <p class="img thumbnail"><a href="filter.html"><img src="/images/examples/filter.png" width="320" height="240" alt="Filter"></a></p>
-    <p>Demonstrating the difference between nearest filter and linear filter.</p>
+    <p>Demonstrates the difference between a nearest filter and a linear filter.</p>
   </div>
   <div class="grid-item-1">
     <h3>Flood Fill</h3>
@@ -24,7 +24,7 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Font</h3>
     <p class="img thumbnail"><a href="font.html"><img src="/images/examples/font.png" width="320" height="240" alt="Font"></a></p>
-    <p>Rendering glyphs of a TrueType font by <code>text.Draw</code>.</p>
+    <p>Rendering glyphs of a TrueType font using <code>text.Draw</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>HSV</h3>
@@ -39,22 +39,22 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Game of Life</h3>
     <p class="img thumbnail"><a href="life.html"><img src="/images/examples/life.png" width="320" height="240" alt="Game of Life"></a></p>
-    <p>Plotting Conway's game of life by <code>ReplacePixels</code>.</p>
+    <p>Drawing Conway's game of life using <code>ReplacePixels</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Mandelbrot</h3>
     <p class="img thumbnail"><a href="mandelbrot.html"><img src="/images/examples/mandelbrot.png" width="320" height="320" alt="Mandelbrot"></a></p>
-    <p>Plotting a Mandelbrot set by <code>ReplacePixels</code> and complex numbers.</p>
+    <p>Plotting a Mandelbrot set with <code>ReplacePixels</code> and complex numbers.</p>
   </div>
   <div class="grid-item-1">
     <h3>Mosaic</h3>
     <p class="img thumbnail"><a href="mosaic.html"><img src="/images/examples/mosaic.png" width="320" height="240" alt="Mosaic"></a></p>
-    <p>Mosaic effect by shrink an image once and enlarge it with nearest filter.</p>
+    <p>Mosaic effect accomplished by shrinking an image once and then enlarging it with a nearest filter.</p>
   </div>
   <div class="grid-item-1">
     <h3>Noise</h3>
     <p class="img thumbnail"><a href="noise.html"><img src="/images/examples/noise.png" width="320" height="240" alt="Noise"></a></p>
-    <p>Rending noise by <code>ReplacePixels</code>.</p>
+    <p>Rendering noise with <code>ReplacePixels</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Particles</h3>
@@ -64,17 +64,17 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Polygons</h3>
     <p class="img thumbnail"><a href="polygons.html"><img src="/images/examples/polygons.png" width="320" height="240" alt="Polygons"></a></p>
-    <p>Rendering polygons by <code>DrawTriangles</code>.</p>
+    <p>Rendering polygons with <code>DrawTriangles</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Sprites</h3>
     <p class="img thumbnail"><a href="sprites.html"><img src="/images/examples/sprites.png" width="320" height="240" alt="Sprites"></a></p>
-    <p>Rendering many images very fast by automatic batches.</p>
+    <p>Rendering many images very fast with automatic batching.</p>
   </div>
   <div class="grid-item-1">
     <h3>Tiles</h3>
-    <p class="img thumbnail"><a href="tiles.html"><img src="/images/examples/tiles.png" width="320" height="240" aalt="Tiles"></a></p>
-    <p>Rednering tiles with <code>DrawImage</code> specifying sub-images.</p>
+    <p class="img thumbnail"><a href="tiles.html"><img src="/images/examples/tiles.png" width="320" height="240" alt="Tiles"></a></p>
+    <p>Rendering tiles with <code>DrawImage</code>, specifying sub-images.</p>
   </div>
 </div>
 <h2>Graphics (Advanced)</h2>
@@ -82,37 +82,37 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Airship</h3>
     <p class="img thumbnail"><a href="airship.html"><img src="/images/examples/airship.png" width="320" height="240" alt="Airship"></a></p>
-    <p>Airship effect like Final Fantasy 6 with pseudo raster scrolling.</p>
+    <p>Mode 7-style airship effect, such as that in FINAL FANTASY 6, with pseudo-raster scrolling.</p>
   </div>
   <div class="grid-item-1">
     <h3>Drag &amp; Drop</h3>
     <p class="img thumbnail"><a href="drag.html"><img src="/images/examples/drag.png" width="320" height="240" alt="Drag &amp; Drop"></a></p>
-    <p>Drag &amp; drop by handling input.</p>
+    <p>Handling user input to implement drag &amp; drop.</p>
   </div>
   <div class="grid-item-1">
     <h3>Hi-DPI</h3>
     <p class="img thumbnail"><a href="highdpi.html"><img src="/images/examples/highdpi.png" width="320" height="240" alt="Hi-DPI"></a></p>
-    <p>Hi-DPI rending by specifing a special scale.</p>
+    <p>Hi-DPI rendering by specifying a special scale.</p>
   </div>
   <div class="grid-item-1">
     <h3>Masking</h3>
     <p class="img thumbnail"><a href="masking.html"><img src="/images/examples/masking.png" width="320" height="240" alt="Masking"></a></p>
-    <p>Masking by <code>DrawImage</code> and a composition mode.</p>
+    <p>Masking with <code>DrawImage</code> and a composition mode.</p>
   </div>
   <div class="grid-item-1">
     <h3>Paint</h3>
     <p class="img thumbnail"><a href="paint.html"><img src="/images/examples/paint.png" width="320" height="240" alt="Paint"></a></p>
-    <p>Drawing tool using an offscreen image as a canvas.</p>
+    <p>A drawing tool that uses an offscreen image as a canvas.</p>
   </div>
   <div class="grid-item-1">
     <h3>Perspective</h3>
     <p class="img thumbnail"><a href="perspective.html"><img src="/images/examples/perspective.png" width="320" height="240" alt="Perspective"></a></p>
-    <p>Pseudo raster scrolling by rendering thin parts of an image.</p>
+    <p>Pseudo-raster scrolling by rendering thin parts of an image.</p>
   </div>
   <div class="grid-item-1">
     <h3>Ray Casting</h3>
     <p class="img thumbnail"><a href="raycasting.html"><img src="/images/examples/raycasting.png" width="320" height="240" alt="Ray Casting"></a></p>
-    <p>Renderng ray casting regions.</p>
+    <p>Rendering regions with ray casting.</p>
   </div>
 </div>
 <h2>Input</h2>
@@ -120,22 +120,22 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Gamepad</h3>
     <p class="img thumbnail"><a href="gamepad.html"><img src="/images/examples/gamepad.png" width="320" height="240" alt="Gamepad"></a></p>
-    <p>Gamepad states like pressed buttons and axes values.</p>
+    <p>Reading and displaying gamepad states, such as pressed buttons and axis values.</p>
   </div>
   <div class="grid-item-1">
     <h3>Keyboard</h3>
     <p class="img thumbnail"><a href="keyboard.html"><img src="/images/examples/keyboard.png" width="320" height="240" alt="Keyboard"></a></p>
-    <p>Keyboard key states.</p>
+    <p>Reading and displaying states of keys on a keyboard.</p>
   </div>
   <div class="grid-item-1">
     <h3>Typewriter</h3>
     <p class="img thumbnail"><a href="typewriter.html"><img src="/images/examples/typewriter.png" width="320" height="240" alt="Typewriter"></a></p>
-    <p>Typewriter-like application by <code>InputChars</code>.</p>
+    <p>Typewriter-like application with <code>InputChars</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Mouse Wheel</h3>
     <p class="img thumbnail"><a href="wheel.html"><img src="/images/examples/wheel.png" width="320" height="240" alt="Mouse Wheel"></a></p>
-    <p>Detecting mouse wheel by <code>Wheel</code>.</p>
+    <p>Detecting the mouse wheel with <code>Wheel</code>.</p>
   </div>
 </div>
 <h2>Audio</h2>
@@ -143,7 +143,7 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Audio</h3>
     <p class="img thumbnail"><a href="audio.html"><img src="/images/examples/audio.png" width="320" height="240" alt="Audio"></a></p>
-    <p>An audio player that plays music with a seek bar.</p>
+    <p>An audio player that plays music and features a seek bar.</p>
   </div>
   <div class="grid-item-1">
     <h3>Piano</h3>
@@ -161,14 +161,17 @@ nn  </div>
   <div class="grid-item-1">
     <h3>2048</h3>
     <p class="img thumbnail"><a href="2048.html"><img src="/images/examples/2048.png" width="400" height="300" alt="2048"></a></p>
+    <p>Use the arrow keys to combine pairs of like numbers. Try to get to 2048!</p>
   </div>
   <div class="grid-item-1">
     <h3>Blocks</h3>
     <p class="img thumbnail"><a href="blocks.html"><img src="/images/examples/blocks.png" width="400" height="300" alt="Blocks"></a></p>
+    <p>A classic falling block puzzle. Use the arrows to move the blocks and the spacebar to rotate them. Complete a row to remove it from the screen.</p>
   </div>
   <div class="grid-item-1">
     <h3>Flappy</h3>
     <p class="img thumbnail"><a href="flappy.html"><img src="/images/examples/flappy.png" width="400" height="300" alt="Flappy"></a></p>
+    <p>Now with 100% more gopher! Press the spacebar to jump. Stay airborne as long as possible!</p>
   </div>
 </div>
 <script>

--- a/contents/examples/tmpl.html
+++ b/contents/examples/tmpl.html
@@ -2,7 +2,7 @@
 <p class="img"><iframe src="_wasm.html?{{.Base}}" width="{{.Width}}" height="{{.Height}}" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/{{.Base}}.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/{{.Base}}</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/{{.Base}}</code></pre>
 {{if .Code}}
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/{{.Base}}/main.go"></pre>

--- a/contents/index.html
+++ b/contents/index.html
@@ -1,7 +1,7 @@
 <div class="grid-container">
   <div class="grid-item-2">
-    <h1 class="big"><span class="main">Ebiten</span><span class="sub">A dead simple 2D game library in Go</span></h1>
-    <p lang="en">Ebiten (/<span class="ipa">ebíteɴ</span>/) is an open-source game library, with which you can develop 2D games with simple API for multi platforms in <a href="https://golang.org/">the Go programming language</a>.</p>
+    <h1 class="big"><span class="main">Ebiten</span><span class="sub">A dead simple 2D game library for Go</span></h1>
+    <p lang="en">Ebiten (/<span class="ipa">ebíteɴ</span>/) is an open source game library for <a href="https://golang.org/">the Go programming language</a>. Ebiten's simple API allows you to quickly and easily develop 2D games that can be deployed across multiple platforms.</p>
     <p lang="ja">Ebiten (読み: えびてん) は<a href="https://golang.org/">プログラミング言語 Go</a> で書かれたオープンソースのゲームライブラリです。シンプルな API を使って、マルチプラットフォームな 2D ゲームを開発することができます。</p>
     <ul class="toplinks">
       <li lang="en"><img src="images/github.png" width="16" height="16" alt="GitHub"><a href="https://github.com/hajimehoshi/ebiten"><code>hajimehoshi/ebiten</code></a> (<a href="/documents/install.html">Install</a>)</li>
@@ -12,35 +12,35 @@
     <p class="img"><img src="images/gopherandgame.png" width="450" alt="Gopher and game developing" style="padding-top: 36px;"></p>
   </div>
 </div>
-<h2 lang="en">What's Ebiten?</h2>
+<h2 lang="en">What is Ebiten?</h2>
 <h2 lang="ja">Ebiten の特徴</h2>
 <div class="grid-container">
   <div class="grid-item-2">
     <h3 lang="en">Dead Simple</h3>
     <h3 lang="ja">とてもシンプル</h3>
     <p class="img"><img src="images/deadsimple.png" width="448" height="224" alt="Dead Simple"></p>
-    <p lang="en">Most rendering operations are represented as drawing an image to an image. Everything is an image: the screen, data from an image file and an offscreen are represented as image objects.</p>
+    <p lang="en">In Ebiten, everything is an image: the screen, data from an image file, and even offscreen items are all represented as image objects. Most rendering operations consist of drawing one image on top of another.</p>
     <p lang="ja">ほとんどの描画命令は画像から画像への描画として表現されます。画面、画像ファイル、オフスクリーンなど、あらゆるものが画像として表現されます。</p>
   </div>
   <div class="grid-item-2">
-    <h3 lang="en">Multi Platforms</h3>
+    <h3 lang="en">Multiplatform</h3>
     <h3 lang="ja">マルチプラットフォーム</h3>
-    <p class="img"><img src="images/multiplatforms.png" width="448" height="224" alt="Multi Platforms"></p>
-    <p lang="en">Ebiten games work on various platforms like desktops (Windows, macOS, Linux, and FreeBSD), web browsers (<a href="https://github.com/gopherjs/gopherjs">GopherJS</a> and WebAssembly), and mobiles (Android and iOS).</p>
+    <p class="img"><img src="images/multiplatforms.png" width="448" height="224" alt="Multiplatform"></p>
+    <p lang="en">Ebiten games work on desktop (Windows, macOS, Linux, and FreeBSD), web browsers (through <a href="https://github.com/gopherjs/gopherjs">GopherJS</a> and WebAssembly), and even on mobile (Android and iOS)! Plus, Ebiten is implemented in pure Go on Windows, so Windows developers do not need to install a C compiler.</p>
     <p lang="ja">Ebiten のゲームは様々な環境で動きます。デスクトップ (Windows、macOS、Linux、FreeBSD)、 Web ブラウザ (<a href="https://github.com/gopherjs/gopherjs">GopherJS</a> と WebAssembly)、モバイル (Android と iOS) で動きます。</p>
   </div>
   <div class="grid-item-2">
     <h3 lang="en">High Performance</h3>
     <h3 lang="ja">高いパフォーマンス</h3>
     <p class="img"><img src="images/highperformance.png" width="448" height="224" alt="High Performance"></p>
-    <p lang="en">While Ebiten's drawing API is very simple, Ebiten games run very fast with GPU power. Multiple images are integrated into a texture atlas internally. Multiple drawing operations are integrated into a batch automatically when possible.</p>
+    <p lang="en">While Ebiten's drawing API is very simple, Ebiten games run very fast with GPU power. Multiple images are integrated into a texture atlas internally, and drawing operations are automatically performed in batch when possible.</p>
     <p lang="ja">Ebiten の API はシンプルですが、ゲームは GPU を活かして高速に実行されます。複数の画像は内部でテクスチャアトラスにまとめられます。複数の描画命令は、可能な限り自動的にバッチにまとめられます。</p>
   </div>
   <div class="grid-item-2">
-    <h3 lang="en">Production Ready</h3>
+    <h3 lang="en">Production-Ready</h3>
     <h3 lang="ja">商用レベルのゲーム</h3>
     <p class="img"><img src="images/productionready.png" width="448" height="224" alt="Production Ready"></p>
-    <p lang="en">Ebiten has capability to develop product-level games. <a href="https://daigostudio.com/bearsrestaurant/">Bear's Restaurant</a>, that reached 400K downloads, is a mobile application in Ebiten.</p>
+    <p lang="en">Ebiten has been used to develop production-level games. One such example is <a href="https://daigostudio.com/bearsrestaurant/">Bear's Restaurant</a>, a mobile application that has been downloaded over 400,000 times.</p>
     <p lang="ja">Ebiten は商用レベルのゲームを作ることができます。<a href="https://daigostudio.com/bearsrestaurant/">くまのレストラン</a>は、 40 万ダウンロードを達成した Ebiten 製のモバイルゲームです。</p>
   </div>
 </div>

--- a/docs/examples/2048.html
+++ b/docs/examples/2048.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?2048" width="420" height="600" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/2048.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/2048</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/2048</code></pre>
 
       </article>
       <footer>

--- a/docs/examples/airship.html
+++ b/docs/examples/airship.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?airship" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/airship.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/airship</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/airship</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/airship/main.go"></pre>

--- a/docs/examples/animation.html
+++ b/docs/examples/animation.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?animation" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/animation.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/animation</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/animation</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/animation/main.go"></pre>

--- a/docs/examples/audio.html
+++ b/docs/examples/audio.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?audio" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/audio.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/audio</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/audio</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/audio/main.go"></pre>

--- a/docs/examples/blocks.html
+++ b/docs/examples/blocks.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?blocks" width="512" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/blocks.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/blocks</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/blocks</code></pre>
 
       </article>
       <footer>

--- a/docs/examples/blur.html
+++ b/docs/examples/blur.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?blur" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/blur.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/blur</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/blur</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/blur/main.go"></pre>

--- a/docs/examples/drag.html
+++ b/docs/examples/drag.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?drag" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/drag.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/drag</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/drag</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/drag/main.go"></pre>

--- a/docs/examples/filter.html
+++ b/docs/examples/filter.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?filter" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/filter.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/filter</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/filter</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/filter/main.go"></pre>

--- a/docs/examples/flappy.html
+++ b/docs/examples/flappy.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?flappy" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/flappy.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/flappy</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/flappy</code></pre>
 
       </article>
       <footer>

--- a/docs/examples/flood.html
+++ b/docs/examples/flood.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?flood" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/flood.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/flood</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/flood</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/flood/main.go"></pre>

--- a/docs/examples/font.html
+++ b/docs/examples/font.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?font" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/font.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/font</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/font</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/font/main.go"></pre>

--- a/docs/examples/gamepad.html
+++ b/docs/examples/gamepad.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?gamepad" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/gamepad.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/gamepad</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/gamepad</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/gamepad/main.go"></pre>

--- a/docs/examples/highdpi.html
+++ b/docs/examples/highdpi.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?highdpi" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/highdpi.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/highdpi</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/highdpi</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/highdpi/main.go"></pre>

--- a/docs/examples/hsv.html
+++ b/docs/examples/hsv.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?hsv" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/hsv.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/hsv</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/hsv</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/hsv/main.go"></pre>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -114,17 +114,17 @@
   <div class="grid-item-1">
     <h3>Animation</h3>
     <p class="img thumbnail"><a href="animation.html"><img src="/images/examples/animation.png" width="320" height="240" alt="Animation"></a></p>
-    <p>Animation by changing the source region of an image by <code>SubImage</code>.</p>
+    <p>Animation by changing the source region of an image using <code>SubImage</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Blur</h3>
     <p class="img thumbnail"><a href="blur.html"><img src="/images/examples/blur.png" width="320" height="240" alt="Blur"></a></p>
-    <p>Bluring an image by rending the same image multiple times.</p>
-nn  </div>
+    <p>Blurring an image by rendering the same image multiple times.</p>
+  </div>
   <div class="grid-item-1">
     <h3>Filter</h3>
     <p class="img thumbnail"><a href="filter.html"><img src="/images/examples/filter.png" width="320" height="240" alt="Filter"></a></p>
-    <p>Demonstrating the difference between nearest filter and linear filter.</p>
+    <p>Demonstrates the difference between a nearest filter and a linear filter.</p>
   </div>
   <div class="grid-item-1">
     <h3>Flood Fill</h3>
@@ -134,7 +134,7 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Font</h3>
     <p class="img thumbnail"><a href="font.html"><img src="/images/examples/font.png" width="320" height="240" alt="Font"></a></p>
-    <p>Rendering glyphs of a TrueType font by <code>text.Draw</code>.</p>
+    <p>Rendering glyphs of a TrueType font using <code>text.Draw</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>HSV</h3>
@@ -149,22 +149,22 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Game of Life</h3>
     <p class="img thumbnail"><a href="life.html"><img src="/images/examples/life.png" width="320" height="240" alt="Game of Life"></a></p>
-    <p>Plotting Conway's game of life by <code>ReplacePixels</code>.</p>
+    <p>Drawing Conway's game of life using <code>ReplacePixels</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Mandelbrot</h3>
     <p class="img thumbnail"><a href="mandelbrot.html"><img src="/images/examples/mandelbrot.png" width="320" height="320" alt="Mandelbrot"></a></p>
-    <p>Plotting a Mandelbrot set by <code>ReplacePixels</code> and complex numbers.</p>
+    <p>Plotting a Mandelbrot set with <code>ReplacePixels</code> and complex numbers.</p>
   </div>
   <div class="grid-item-1">
     <h3>Mosaic</h3>
     <p class="img thumbnail"><a href="mosaic.html"><img src="/images/examples/mosaic.png" width="320" height="240" alt="Mosaic"></a></p>
-    <p>Mosaic effect by shrink an image once and enlarge it with nearest filter.</p>
+    <p>Mosaic effect accomplished by shrinking an image once and then enlarging it with a nearest filter.</p>
   </div>
   <div class="grid-item-1">
     <h3>Noise</h3>
     <p class="img thumbnail"><a href="noise.html"><img src="/images/examples/noise.png" width="320" height="240" alt="Noise"></a></p>
-    <p>Rending noise by <code>ReplacePixels</code>.</p>
+    <p>Rendering noise with <code>ReplacePixels</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Particles</h3>
@@ -174,17 +174,17 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Polygons</h3>
     <p class="img thumbnail"><a href="polygons.html"><img src="/images/examples/polygons.png" width="320" height="240" alt="Polygons"></a></p>
-    <p>Rendering polygons by <code>DrawTriangles</code>.</p>
+    <p>Rendering polygons with <code>DrawTriangles</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Sprites</h3>
     <p class="img thumbnail"><a href="sprites.html"><img src="/images/examples/sprites.png" width="320" height="240" alt="Sprites"></a></p>
-    <p>Rendering many images very fast by automatic batches.</p>
+    <p>Rendering many images very fast with automatic batching.</p>
   </div>
   <div class="grid-item-1">
     <h3>Tiles</h3>
-    <p class="img thumbnail"><a href="tiles.html"><img src="/images/examples/tiles.png" width="320" height="240" aalt="Tiles"></a></p>
-    <p>Rednering tiles with <code>DrawImage</code> specifying sub-images.</p>
+    <p class="img thumbnail"><a href="tiles.html"><img src="/images/examples/tiles.png" width="320" height="240" alt="Tiles"></a></p>
+    <p>Rendering tiles with <code>DrawImage</code>, specifying sub-images.</p>
   </div>
 </div>
 <h2>Graphics (Advanced)</h2>
@@ -192,37 +192,37 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Airship</h3>
     <p class="img thumbnail"><a href="airship.html"><img src="/images/examples/airship.png" width="320" height="240" alt="Airship"></a></p>
-    <p>Airship effect like Final Fantasy 6 with pseudo raster scrolling.</p>
+    <p>Mode 7-style airship effect, such as that in FINAL FANTASY 6, with pseudo-raster scrolling.</p>
   </div>
   <div class="grid-item-1">
     <h3>Drag &amp; Drop</h3>
     <p class="img thumbnail"><a href="drag.html"><img src="/images/examples/drag.png" width="320" height="240" alt="Drag &amp; Drop"></a></p>
-    <p>Drag &amp; drop by handling input.</p>
+    <p>Handling user input to implement drag &amp; drop.</p>
   </div>
   <div class="grid-item-1">
     <h3>Hi-DPI</h3>
     <p class="img thumbnail"><a href="highdpi.html"><img src="/images/examples/highdpi.png" width="320" height="240" alt="Hi-DPI"></a></p>
-    <p>Hi-DPI rending by specifing a special scale.</p>
+    <p>Hi-DPI rendering by specifying a special scale.</p>
   </div>
   <div class="grid-item-1">
     <h3>Masking</h3>
     <p class="img thumbnail"><a href="masking.html"><img src="/images/examples/masking.png" width="320" height="240" alt="Masking"></a></p>
-    <p>Masking by <code>DrawImage</code> and a composition mode.</p>
+    <p>Masking with <code>DrawImage</code> and a composition mode.</p>
   </div>
   <div class="grid-item-1">
     <h3>Paint</h3>
     <p class="img thumbnail"><a href="paint.html"><img src="/images/examples/paint.png" width="320" height="240" alt="Paint"></a></p>
-    <p>Drawing tool using an offscreen image as a canvas.</p>
+    <p>A drawing tool that uses an offscreen image as a canvas.</p>
   </div>
   <div class="grid-item-1">
     <h3>Perspective</h3>
     <p class="img thumbnail"><a href="perspective.html"><img src="/images/examples/perspective.png" width="320" height="240" alt="Perspective"></a></p>
-    <p>Pseudo raster scrolling by rendering thin parts of an image.</p>
+    <p>Pseudo-raster scrolling by rendering thin parts of an image.</p>
   </div>
   <div class="grid-item-1">
     <h3>Ray Casting</h3>
     <p class="img thumbnail"><a href="raycasting.html"><img src="/images/examples/raycasting.png" width="320" height="240" alt="Ray Casting"></a></p>
-    <p>Renderng ray casting regions.</p>
+    <p>Rendering regions with ray casting.</p>
   </div>
 </div>
 <h2>Input</h2>
@@ -230,22 +230,22 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Gamepad</h3>
     <p class="img thumbnail"><a href="gamepad.html"><img src="/images/examples/gamepad.png" width="320" height="240" alt="Gamepad"></a></p>
-    <p>Gamepad states like pressed buttons and axes values.</p>
+    <p>Reading and displaying gamepad states, such as pressed buttons and axis values.</p>
   </div>
   <div class="grid-item-1">
     <h3>Keyboard</h3>
     <p class="img thumbnail"><a href="keyboard.html"><img src="/images/examples/keyboard.png" width="320" height="240" alt="Keyboard"></a></p>
-    <p>Keyboard key states.</p>
+    <p>Reading and displaying states of keys on a keyboard.</p>
   </div>
   <div class="grid-item-1">
     <h3>Typewriter</h3>
     <p class="img thumbnail"><a href="typewriter.html"><img src="/images/examples/typewriter.png" width="320" height="240" alt="Typewriter"></a></p>
-    <p>Typewriter-like application by <code>InputChars</code>.</p>
+    <p>Typewriter-like application with <code>InputChars</code>.</p>
   </div>
   <div class="grid-item-1">
     <h3>Mouse Wheel</h3>
     <p class="img thumbnail"><a href="wheel.html"><img src="/images/examples/wheel.png" width="320" height="240" alt="Mouse Wheel"></a></p>
-    <p>Detecting mouse wheel by <code>Wheel</code>.</p>
+    <p>Detecting the mouse wheel with <code>Wheel</code>.</p>
   </div>
 </div>
 <h2>Audio</h2>
@@ -253,7 +253,7 @@ nn  </div>
   <div class="grid-item-1">
     <h3>Audio</h3>
     <p class="img thumbnail"><a href="audio.html"><img src="/images/examples/audio.png" width="320" height="240" alt="Audio"></a></p>
-    <p>An audio player that plays music with a seek bar.</p>
+    <p>An audio player that plays music and features a seek bar.</p>
   </div>
   <div class="grid-item-1">
     <h3>Piano</h3>
@@ -271,14 +271,17 @@ nn  </div>
   <div class="grid-item-1">
     <h3>2048</h3>
     <p class="img thumbnail"><a href="2048.html"><img src="/images/examples/2048.png" width="400" height="300" alt="2048"></a></p>
+    <p>Use the arrow keys to combine pairs of like numbers. Try to get to 2048!</p>
   </div>
   <div class="grid-item-1">
     <h3>Blocks</h3>
     <p class="img thumbnail"><a href="blocks.html"><img src="/images/examples/blocks.png" width="400" height="300" alt="Blocks"></a></p>
+    <p>A classic falling block puzzle. Use the arrows to move the blocks and the spacebar to rotate them. Complete a row to remove it from the screen.</p>
   </div>
   <div class="grid-item-1">
     <h3>Flappy</h3>
     <p class="img thumbnail"><a href="flappy.html"><img src="/images/examples/flappy.png" width="400" height="300" alt="Flappy"></a></p>
+    <p>Now with 100% more gopher! Press the spacebar to jump. Stay airborne as long as possible!</p>
   </div>
 </div>
 <script>

--- a/docs/examples/infinitescroll.html
+++ b/docs/examples/infinitescroll.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?infinitescroll" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/infinitescroll.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/infinitescroll</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/infinitescroll</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/infinitescroll/main.go"></pre>

--- a/docs/examples/keyboard.html
+++ b/docs/examples/keyboard.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?keyboard" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/keyboard.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/keyboard</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/keyboard</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/keyboard/main.go"></pre>

--- a/docs/examples/life.html
+++ b/docs/examples/life.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?life" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/life.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/life</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/life</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/life/main.go"></pre>

--- a/docs/examples/mandelbrot.html
+++ b/docs/examples/mandelbrot.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?mandelbrot" width="640" height="640" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/mandelbrot.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/mandelbrot</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/mandelbrot</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/mandelbrot/main.go"></pre>

--- a/docs/examples/masking.html
+++ b/docs/examples/masking.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?masking" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/masking.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/masking</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/masking</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/masking/main.go"></pre>

--- a/docs/examples/mosaic.html
+++ b/docs/examples/mosaic.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?mosaic" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/mosaic.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/mosaic</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/mosaic</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/mosaic/main.go"></pre>

--- a/docs/examples/noise.html
+++ b/docs/examples/noise.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?noise" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/noise.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/noise</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/noise</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/noise/main.go"></pre>

--- a/docs/examples/paint.html
+++ b/docs/examples/paint.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?paint" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/paint.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/paint</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/paint</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/paint/main.go"></pre>

--- a/docs/examples/particles.html
+++ b/docs/examples/particles.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?particles" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/particles.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/particles</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/particles</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/particles/main.go"></pre>

--- a/docs/examples/perspective.html
+++ b/docs/examples/perspective.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?perspective" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/perspective.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/perspective</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/perspective</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/perspective/main.go"></pre>

--- a/docs/examples/piano.html
+++ b/docs/examples/piano.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?piano" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/piano.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/piano</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/piano</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/piano/main.go"></pre>

--- a/docs/examples/polygons.html
+++ b/docs/examples/polygons.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?polygons" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/polygons.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/polygons</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/polygons</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/polygons/main.go"></pre>

--- a/docs/examples/raycasting.html
+++ b/docs/examples/raycasting.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?raycasting" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/raycasting.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/raycasting</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/raycasting</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/raycasting/main.go"></pre>

--- a/docs/examples/sinewave.html
+++ b/docs/examples/sinewave.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?sinewave" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/sinewave.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/sinewave</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/sinewave</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/sinewave/main.go"></pre>

--- a/docs/examples/sprites.html
+++ b/docs/examples/sprites.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?sprites" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/sprites.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/sprites</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/sprites</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/sprites/main.go"></pre>

--- a/docs/examples/tiles.html
+++ b/docs/examples/tiles.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?tiles" width="480" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/tiles.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/tiles</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/tiles</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/tiles/main.go"></pre>

--- a/docs/examples/typewriter.html
+++ b/docs/examples/typewriter.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?typewriter" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/typewriter.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/typewriter</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/typewriter</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/typewriter/main.go"></pre>

--- a/docs/examples/wheel.html
+++ b/docs/examples/wheel.html
@@ -112,7 +112,7 @@
 <p class="img"><iframe src="_wasm.html?wheel" width="640" height="480" allow="autoplay"></iframe></p>
 <p style="display: none;"><img id="meta-share" src="/images/examples/wheel.png"></p>
 <h2>Run locally</h2>
-<pre><coce>go run -tags=example github.com/hajimehoshi/ebiten/examples/wheel</code></pre>
+<pre><code>go run -tags=example github.com/hajimehoshi/ebiten/examples/wheel</code></pre>
 
 <h2>Code</h2>
 <pre data-codesrc="https://raw.githubusercontent.com/hajimehoshi/ebiten/master/examples/wheel/main.go"></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,8 +62,8 @@
       <article>
         <div class="grid-container">
   <div class="grid-item-2">
-    <h1 class="big"><span class="main">Ebiten</span><span class="sub">A dead simple 2D game library in Go</span></h1>
-    <p lang="en">Ebiten (/<span class="ipa">ebíteɴ</span>/) is an open-source game library, with which you can develop 2D games with simple API for multi platforms in <a href="https://golang.org/">the Go programming language</a>.</p>
+    <h1 class="big"><span class="main">Ebiten</span><span class="sub">A dead simple 2D game library for Go</span></h1>
+    <p lang="en">Ebiten (/<span class="ipa">ebíteɴ</span>/) is an open source game library for <a href="https://golang.org/">the Go programming language</a>. Ebiten's simple API allows you to quickly and easily develop 2D games that can be deployed across multiple platforms.</p>
     <p lang="ja">Ebiten (読み: えびてん) は<a href="https://golang.org/">プログラミング言語 Go</a> で書かれたオープンソースのゲームライブラリです。シンプルな API を使って、マルチプラットフォームな 2D ゲームを開発することができます。</p>
     <ul class="toplinks">
       <li lang="en"><img src="images/github.png" width="16" height="16" alt="GitHub"><a href="https://github.com/hajimehoshi/ebiten"><code>hajimehoshi/ebiten</code></a> (<a href="/documents/install.html">Install</a>)</li>
@@ -74,35 +74,35 @@
     <p class="img"><img src="images/gopherandgame.png" width="450" alt="Gopher and game developing" style="padding-top: 36px;"></p>
   </div>
 </div>
-<h2 lang="en">What's Ebiten?</h2>
+<h2 lang="en">What is Ebiten?</h2>
 <h2 lang="ja">Ebiten の特徴</h2>
 <div class="grid-container">
   <div class="grid-item-2">
     <h3 lang="en">Dead Simple</h3>
     <h3 lang="ja">とてもシンプル</h3>
     <p class="img"><img src="images/deadsimple.png" width="448" height="224" alt="Dead Simple"></p>
-    <p lang="en">Most rendering operations are represented as drawing an image to an image. Everything is an image: the screen, data from an image file and an offscreen are represented as image objects.</p>
+    <p lang="en">In Ebiten, everything is an image: the screen, data from an image file, and even offscreen items are all represented as image objects. Most rendering operations consist of drawing one image on top of another.</p>
     <p lang="ja">ほとんどの描画命令は画像から画像への描画として表現されます。画面、画像ファイル、オフスクリーンなど、あらゆるものが画像として表現されます。</p>
   </div>
   <div class="grid-item-2">
-    <h3 lang="en">Multi Platforms</h3>
+    <h3 lang="en">Multiplatform</h3>
     <h3 lang="ja">マルチプラットフォーム</h3>
-    <p class="img"><img src="images/multiplatforms.png" width="448" height="224" alt="Multi Platforms"></p>
-    <p lang="en">Ebiten games work on various platforms like desktops (Windows, macOS, Linux, and FreeBSD), web browsers (<a href="https://github.com/gopherjs/gopherjs">GopherJS</a> and WebAssembly), and mobiles (Android and iOS).</p>
+    <p class="img"><img src="images/multiplatforms.png" width="448" height="224" alt="Multiplatform"></p>
+    <p lang="en">Ebiten games work on desktop (Windows, macOS, Linux, and FreeBSD), web browsers (through <a href="https://github.com/gopherjs/gopherjs">GopherJS</a> and WebAssembly), and even on mobile (Android and iOS)! Plus, Ebiten is implemented in pure Go on Windows, so Windows developers do not need to install a C compiler.</p>
     <p lang="ja">Ebiten のゲームは様々な環境で動きます。デスクトップ (Windows、macOS、Linux、FreeBSD)、 Web ブラウザ (<a href="https://github.com/gopherjs/gopherjs">GopherJS</a> と WebAssembly)、モバイル (Android と iOS) で動きます。</p>
   </div>
   <div class="grid-item-2">
     <h3 lang="en">High Performance</h3>
     <h3 lang="ja">高いパフォーマンス</h3>
     <p class="img"><img src="images/highperformance.png" width="448" height="224" alt="High Performance"></p>
-    <p lang="en">While Ebiten's drawing API is very simple, Ebiten games run very fast with GPU power. Multiple images are integrated into a texture atlas internally. Multiple drawing operations are integrated into a batch automatically when possible.</p>
+    <p lang="en">While Ebiten's drawing API is very simple, Ebiten games run very fast with GPU power. Multiple images are integrated into a texture atlas internally, and drawing operations are automatically performed in batch when possible.</p>
     <p lang="ja">Ebiten の API はシンプルですが、ゲームは GPU を活かして高速に実行されます。複数の画像は内部でテクスチャアトラスにまとめられます。複数の描画命令は、可能な限り自動的にバッチにまとめられます。</p>
   </div>
   <div class="grid-item-2">
-    <h3 lang="en">Production Ready</h3>
+    <h3 lang="en">Production-Ready</h3>
     <h3 lang="ja">商用レベルのゲーム</h3>
     <p class="img"><img src="images/productionready.png" width="448" height="224" alt="Production Ready"></p>
-    <p lang="en">Ebiten has capability to develop product-level games. <a href="https://daigostudio.com/bearsrestaurant/">Bear's Restaurant</a>, that reached 400K downloads, is a mobile application in Ebiten.</p>
+    <p lang="en">Ebiten has been used to develop production-level games. One such example is <a href="https://daigostudio.com/bearsrestaurant/">Bear's Restaurant</a>, a mobile application that has been downloaded over 400,000 times.</p>
     <p lang="ja">Ebiten は商用レベルのゲームを作ることができます。<a href="https://daigostudio.com/bearsrestaurant/">くまのレストラン</a>は、 40 万ダウンロードを達成した Ebiten 製のモバイルゲームです。</p>
   </div>
 </div>

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -171,8 +171,10 @@ func Run(url, description string) error {
 		if s != "" {
 			share = url + s
 		}
+
 		feed := ""
-		if strings.HasPrefix(rel, "blog/") {
+		// Checks for "blog/" on Linux, "blog\" on Windows
+		if strings.HasPrefix(rel, "blog"+string(filepath.Separator)) {
 			feed = url + "/blog/feed.xml"
 		}
 


### PR DESCRIPTION
# Overview

This PR adds some changes to the homepage & examples page to fix typos and make the English sound more natural. I also had to make a minor modification to `gen.go` so that it works correctly on Windows.

# Changes

* Updated `gen.go` so that the `blog/` directory is found when running `go generate` on Windows. Since Windows uses `\` as its separator, the hardcoded string `"blog/"` wasn't found, so that whole directory did not parse correctly.
* Checked & updated the English on the homepage (`index.html`) to fix typos and make the wording sound more natural.
  * Added a blurb about no cgo on Windows to the "Multiplatform" section, since I think that's a really important & nice feature of Ebiten.
  * I do not speak much Japanese, so @hajimehoshi, you might want to add a similar sentence to the Japanese part!
* Checked & updated the English on the examples index page (`examples/index.html`) to fix typos and make the wording sound more natural.
  * Also added some fun descriptions to the games at the bottom of the examples page.