### PR TITLE
Tell GitHub that the feed.xml and *.html files in docs are generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/blog/feed.xml linguist-generated
+docs/**/*.html linguist-generated


### PR DESCRIPTION
This'll show these collapsed-by-default in pull request reviews, omit them from the repo's language stats, and maybe also give developers a hint that these files are generated and shouldn't be edited.